### PR TITLE
Fix content-type var

### DIFF
--- a/src/juxt/reap/alpha/rfc7231.clj
+++ b/src/juxt/reap/alpha/rfc7231.clj
@@ -346,9 +346,6 @@
 ;; Content-Location = absolute-URI / partial-URI
 ;; TODO
 
-;; Content-Type = media-type
-(def content-type media-type)
-
 ;; Date = HTTP-date
 (def date http-date)
 
@@ -709,6 +706,9 @@
            (p/ignore (p/pattern-parser (re-pattern ";")))
            (p/ignore (p/pattern-parser (re-pattern OWS)))
            (:juxt.reap/decode parameter))))))))})
+
+;; Content-Type = media-type
+(def content-type media-type)
 
 ;; method = token
 (def ^String method token)


### PR DESCRIPTION
It was pointing at media-type before it was bound to a value, this
caused the require to not work.