### PR TITLE
Fix link to Allen's interval algebra in the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -221,7 +221,7 @@ expression]. Regexes provide the performance.
 
 ==== Allen's Interval Algebra (1983)
 
-https://en.wikipedia.org/wiki/Allen's_interval_algebra[Allen's interval algebra]
+https://en.wikipedia.org/wiki/Allen%27s_interval_algebra[Allen's interval algebra]
 allows character intervals to be manipulated and combined, to form optimal
 ranges which optimise the performance of the regular expression.
 


### PR DESCRIPTION
For me the link was going to https://en.wikipedia.org/wiki/Allen%E2%80%99s_interval_algebra instead of https://en.wikipedia.org/wiki/Allen%27s_interval_algebra

NOTE: ’ instead of '